### PR TITLE
Correcting property name for enabling file upload task

### DIFF
--- a/en/docs/how-tos/analytics-for-microgateway.md
+++ b/en/docs/how-tos/analytics-for-microgateway.md
@@ -138,7 +138,7 @@ enable=true
 uploadingTimeSpanInMillis=600000
 uploadingEndpoint="https://localhost:9444/analytics/v1.0/usage/upload-file"
 rotatingPeriod=60000
-task.uploadFiles=true
+taskUploadFiles=true
 username="admin"
 password="admin"
 ```


### PR DESCRIPTION
The option task.uploadFiles=true is not correct. At runtime this even throws "Caused by: java.lang.IllegalStateException: Invalid key on line 32: task.uploadFiles" error and microgateway doesn't even start.

Correct entry should be taskUploadFiles=true. This is correctly stated in the reference page - https://mg.docs.wso2.com/en/latest/reference/configurations/micro-gw.conf/

### Purpose
<!-- Short description of the issue you are going to solve with this PR. -->

### Issues
<!-- Link github issues that are going to be solved with this PR. Format should be: Fixes #123 -->
Fixes #

---
#### Maintainers: Check before merge
- [ ] Manual verification
