### PR TITLE
Add arm compatibility to installation prerequisites

### DIFF
--- a/en/docs/install-and-setup/install-on-vm.md
+++ b/en/docs/install-and-setup/install-on-vm.md
@@ -94,4 +94,4 @@ Follow the instructions below to install the WSO2 API Microgateway related binar
 
 ### ARM compatibility
 
-WSO2 Microgateway Toolkit and Runtime are compatible with ARM processors. It can run on ARM-based systems, such as those with Apple Silicon or ARM-based Linux distributions.
+WSO2 Microgateway Toolkit and Runtime are compatible with ARM processors. They can run on ARM-based systems, such as those with Apple Silicon or ARM-based Linux distributions.

--- a/en/docs/install-and-setup/install-on-vm.md
+++ b/en/docs/install-and-setup/install-on-vm.md
@@ -91,3 +91,7 @@ Follow the instructions below to install the WSO2 API Microgateway related binar
     2.  Set the Microgateway runtime distribution path using the UI in Windows.
     </details>
 5.  Optionally, [configure WSO2 API Microgateway Runtime with WSO2 API Manager 3.2.0]({{base_path}}/install-and-setup/configuration-for-wso2-api-manager/#configuring-the-microgateway-32x-runtime) .
+
+### ARM compatibility
+
+WSO2 Microgateway Toolkit and Runtime are compatible with ARM processors. It can run on ARM-based systems, such as those with Apple Silicon or ARM-based Linux distributions.


### PR DESCRIPTION
## Purpose
> Test compatibility of WSO2 API Microgateway 3.2.0 on Linux ARM.

### Approach
> Tested the following on a VM on Azure with Ubuntu 24.04 and arm64 CPU architecture.
- API Microgateway 3.2.0 toolkit and runtime and API creation and invocation.