### PR TITLE
Add APIM 4.6.0 to Microgateway compatibility docs

### DIFF
--- a/en/docs/faqs.md
+++ b/en/docs/faqs.md
@@ -37,6 +37,8 @@ You need to append the full path of the `/bin` folder of the extracted WSO2 API 
 - Java 17
 
 ##### What versions of WSO2 API-M are compatible with WSO2 API Microgateway 3.2.0?
+-   [WSO2 API Manager 4.6.0](https://apim.docs.wso2.com/en/4.6.0/)
+-   [WSO2 API Manager 4.5.0](https://apim.docs.wso2.com/en/4.5.0/)
 -   [WSO2 API Manager 4.4.0](https://apim.docs.wso2.com/en/4.4.0/)
 -   [WSO2 API Manager 4.3.0](https://apim.docs.wso2.com/en/4.3.0/)
 -   [WSO2 API Manager 4.2.0](https://apim.docs.wso2.com/en/4.2.0/)
@@ -61,6 +63,8 @@ You need to append the full path of the `/bin` folder of the extracted WSO2 API 
     WSO2 API Manager 4.2.0 | 116
     WSO2 API Manager 4.3.0 | 27
     WSO2 API Manager 4.4.0 | G/A
+    WSO2 API Manager 4.5.0 | G/A
+    WSO2 API Manager 4.6.0 | G/A
 
 ##### What version of the Ballerina should be used to write extensions, interceptors, etc for WSO2 API Microgateway 3.2.0?
 

--- a/en/docs/install-and-setup/configuration-for-wso2-api-manager.md
+++ b/en/docs/install-and-setup/configuration-for-wso2-api-manager.md
@@ -48,6 +48,8 @@ Follow the instructions below to configure the WSO2 Microgateway Toolkit and th
     | 4.2.0               | v4               | v0.17       |
     | 4.3.0               | v4               | v0.17       |
     | 4.4.0               | v4               | v0.17       |
+    | 4.5.0               | v4               | v0.17       |
+    | 4.6.0               | v4               | v0.17       |
 
     Open the `<MGW_TOOLKIT_HOME>/conf/toolkit-config.toml` file and change the `restVersion` and `dcrVersion` accordingly.
 


### PR DESCRIPTION
### Purpose
This pull request updates documentation to include support for WSO2 API Manager versions 4.5.0 and 4.6.0. The changes ensure that users are aware of compatibility and configuration details for these new versions.

Compatibility and documentation updates:

* Added references to WSO2 API Manager 4.5.0 and 4.6.0 in the compatibility list for WSO2 API Microgateway 3.2.0 in `en/docs/faqs.md`.
* Updated the compatibility matrix to include WSO2 API Manager 4.5.0 and 4.6.0 in `en/docs/faqs.md`.
* Updated the configuration table in `en/docs/install-and-setup/configuration-for-wso2-api-manager.md` to include WSO2 API Manager 4.5.0 and 4.6.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced compatibility documentation with support for WSO2 API Manager versions 4.5.0 and 4.6.0, including updates to FAQs and configuration guides for Microgateway 3.2.0 and Toolkit configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->